### PR TITLE
Updated for new dump list HTML

### DIFF
--- a/download_wd_history.sh
+++ b/download_wd_history.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-curl https://dumps.wikimedia.org/wikidatawiki/latest/ | grep -Po "wikidatawiki/[0-9]+/wikidatawiki-[0-9]+-pages-meta-history[0-9]+\.xml-[p0-9]+\.bz2" | while read -r url ; do
+curl https://dumps.wikimedia.org/wikidatawiki/latest/ | grep -Po "wikidatawiki-latest-pages-meta-history[0-9]+\.xml-[p0-9]+\.bz2" | while read -r url ; do
 echo $url
-wget -c "https://dumps.wikimedia.org/$url"
+wget -c "https://dumps.wikimedia.org/wikidata/latest/$url"
 done


### PR DESCRIPTION
It seems that the dumps HTML does not contain absolute addresses anymore, but just the relative one. Adapting to that.